### PR TITLE
feat(payroll, dashboard): change column types to decimal(10,2) and update views

### DIFF
--- a/app/controllers/employee/dashboard_controller.rb
+++ b/app/controllers/employee/dashboard_controller.rb
@@ -16,15 +16,30 @@ module Employee
         @released_cash_advances = current_user.cash_adv_requests.where(status: ['released', 'on-going', 'settled']).count
         CashAdvRequest.where(status: ['released', 'on-going', 'settled']).count
 
-        day_cutoff = Date.today.day <= 15 ? 15 : 30
+        # day_cutoff = Date.today.day <= 15 ? 15 : 30
 
-        day_cutoff = Date.today.day <= 15 ? 15 : 30
+        # day_cutoff = Date.today.day <= 15 ? 15 : 30
+        # @due_next_payroll_records = RepaymentSchedule
+        # .includes(cash_adv_request: :employee)
+        # .where("DAY(due_date) = ?", day_cutoff)
+        # .where("due_date <= ?", Time.current.end_of_month)
+        # .where(status: "pending")
+        # .where("cash_adv_requests.employee_id = ?", current_user.employee_id)
+
+        if Date.today.day <= 15
+          start_date = Date.today.beginning_of_month
+          end_date = Date.today.change(day: 15)
+        else
+          start_date = Date.today.change(day: 16)
+          end_date = Date.today.end_of_month
+        end
+        
         @due_next_payroll_records = RepaymentSchedule
-        .includes(cash_adv_request: :employee)
-        .where("DAY(due_date) = ?", day_cutoff)
-        .where("due_date <= ?", Time.current.end_of_month)
-        .where(status: "pending")
-        .where("cash_adv_requests.employee_id = ?", current_user.employee_id)
+          .joins(cash_adv_request: :employee)
+          .includes(cash_adv_request: :employee)
+          .where(due_date: start_date..end_date)
+          .where(status: "pending")
+          .where(cash_adv_requests: { employee_id: current_user.employee_id })
 
         @current_user_approved_cash_advances = current_user.cash_adv_requests.where(status: 'approved').count
       

--- a/app/controllers/payrolls_controller.rb
+++ b/app/controllers/payrolls_controller.rb
@@ -1,67 +1,68 @@
-    class PayrollsController < ApplicationController
-        def preview
-        @payroll = Payroll.find(params[:id])
-        @user = @payroll.user  
-    
-        pdf = Prawn::Document.new
-    
-        
-        pdf.text "Payslip", size: 24, style: :bold, align: :center
-        pdf.move_down 20
-    
-        
-        pdf.text "Employee Details", style: :bold
-        pdf.text "Name: #{@user.f_name} #{@user.m_name} #{@user.l_name}"
-        pdf.text "Employee ID: #{@user.employee_id}"
-        pdf.text "Job Title: #{@user.job_title || 'N/A'}"
-        pdf.text "Hire Date: #{@user.hire_date&.strftime('%B %d, %Y') || 'N/A'}"
-        pdf.text "Pay Period: #{@payroll.description }"
-        pdf.move_down 10
-    
-        
-        pdf.text "Earnings", style: :bold
-        pdf.table([
-            ["Description", "Amount"],
-            ["Basic Salary", @payroll.basic || 0],
-            ["Allowances", 0],
-            ["Overtime", 0]
-        ], header: true, width: pdf.bounds.width)
-        pdf.move_down 10
-    
-        
-        pdf.text "Deductions", style: :bold
-        pdf.table([
-            ["Description", "Amount"],
-            ["SSS", @payroll.sss || 0],
-            ["PhilHealth", @payroll.philhealth || 0],
-            ["PAGIBIG", @payroll.pagibig || 0],
-            ["Cash Advance", @payroll.cashadv || 0]
-        ], header: true, width: pdf.bounds.width)
-        pdf.move_down 10
-    
-        
-        total_earnings = (@payroll.basic || 0)
-        total_deductions = (@payroll.sss || 0) + (@payroll.philhealth || 0) + (@payroll.pagibig || 0) + (@payroll.cashadv || 0)
-        net_pay = total_earnings - total_deductions
-    
-        pdf.text "Summary", style: :bold
-        pdf.table([
-            ["Total Earnings", "PHP #{'%.2f' % total_earnings}"],
-            ["Total Deductions", "PHP #{'%.2f' % total_deductions}"],
-            ["Net Pay", "PHP #{'%.2f' % net_pay}"]
-        ], width: pdf.bounds.width)
-        pdf.move_down 20
-    
-        
-        pdf.text "This is a system-generated payslip.", size: 10, align: :center
-        pdf.text "Contact finance if you have any questions or dispute regarding your payslip.", size: 10, align: :center
-    
-        
-        send_data pdf.render,
-                    filename: "payroll_#{@payroll.id}.pdf",
-                    type: 'application/pdf',
-                    disposition: 'inline',
-                    stream: true
-        end
+class PayrollsController < ApplicationController
+    include ActionView::Helpers::NumberHelper  # Make sure this line is included
+  
+    def preview
+      @payroll = Payroll.find(params[:id])
+      @user = @payroll.user  
+  
+      pdf = Prawn::Document.new
+  
+      # Employee details
+      pdf.text "Payslip", size: 24, style: :bold, align: :center
+      pdf.move_down 20
+  
+      pdf.text "Employee Details", style: :bold
+      pdf.text "Name: #{@user.f_name} #{@user.m_name} #{@user.l_name}"
+      pdf.text "Employee ID: #{@user.employee_id}"
+      pdf.text "Job Title: #{@user.job_title || 'N/A'}"
+      pdf.text "Hire Date: #{@user.hire_date&.strftime('%B %d, %Y') || 'N/A'}"
+      pdf.text "Pay Period: #{@payroll.description }"
+      pdf.move_down 10
+  
+      # Earnings section
+      pdf.text "Earnings", style: :bold
+      pdf.table([
+        ["Description", "Amount"],
+        ["Basic Salary", number_to_currency(@payroll.basic, precision: 2, delimiter: ',', unit: '')],
+        ["Allowances", number_to_currency(0, precision: 2, delimiter: ',', unit: '')],
+        ["Overtime", number_to_currency(0, precision: 2, delimiter: ',', unit: '')]
+      ], header: true, width: pdf.bounds.width)
+      pdf.move_down 10
+  
+      # Deductions section
+      pdf.text "Deductions", style: :bold
+      pdf.table([
+        ["Description", "Amount"],
+        ["SSS", number_to_currency(@payroll.sss, precision: 2, delimiter: ',', unit: '')],
+        ["PhilHealth", number_to_currency(@payroll.philhealth, precision: 2, delimiter: ',', unit: '')],
+        ["PAGIBIG", number_to_currency(@payroll.pagibig, precision: 2, delimiter: ',', unit: '')],
+        ["Cash Advance", number_to_currency(@payroll.cashadv, precision: 2, delimiter: ',', unit: '')]
+      ], header: true, width: pdf.bounds.width)
+      pdf.move_down 10
+  
+      # Summary section
+      total_earnings = (@payroll.basic || 0)
+      total_deductions = (@payroll.sss || 0) + (@payroll.philhealth || 0) + (@payroll.pagibig || 0) + (@payroll.cashadv || 0)
+      net_pay = total_earnings - total_deductions
+  
+      pdf.text "Summary", style: :bold
+      pdf.table([
+        ["Total Earnings", number_to_currency(total_earnings, precision: 2, delimiter: ',', unit: '')],
+        ["Total Deductions", number_to_currency(total_deductions, precision: 2, delimiter: ',', unit: '')],
+        ["Net Pay", number_to_currency(net_pay, precision: 2, delimiter: ',', unit: '')]
+      ], width: pdf.bounds.width)
+      pdf.move_down 20
+  
+      # Footer note
+      pdf.text "This is a system-generated payslip.", size: 10, align: :center
+      pdf.text "Contact finance if you have any questions or disputes regarding your payslip.", size: 10, align: :center
+  
+      # Sending the PDF
+      send_data pdf.render,
+                filename: "payroll_#{@payroll.id}.pdf",
+                type: 'application/pdf',
+                disposition: 'inline',
+                stream: true
     end
-    
+  end
+  

--- a/app/helpers/generate_payroll.rb
+++ b/app/helpers/generate_payroll.rb
@@ -1,7 +1,7 @@
 class GeneratePayroll
     def self.perform
       today = Date.today
-      return unless today.day == 16 #[15, 30].include?(today.day) #change return to day today to test
+      return unless today.day == 24 #[15, 24].include?(today.day) #change return to day today to test
   
       is_first_cutoff = today.day == 15
       description_date = today.strftime('%B %d, %Y')
@@ -28,9 +28,11 @@ class GeneratePayroll
           pagibig = 0
           net_amount = (basic - cash_advance_deduction).round(2)
         else
-          sss = salary < 20_000 ? 500 : 1000
-          philhealth = ((salary * 0.05) / 2.0).round(2)
-          pagibig = 200
+          contributions = User.gov_contribution(salary)
+          sss = contributions[:sss]
+          philhealth = contributions[:philhealth].round(2)
+          pagibig = contributions[:pagibig]
+
           net_amount = (basic - (sss + philhealth + pagibig + cash_advance_deduction)).round(2)
         end
   

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -47,6 +47,7 @@ every 1.minute do
     cd /home/precious/code/cash_advance && RAILS_ENV=development bundle exec rails runner 'RepaymentSchedule.update_due_statuses' >> /home/precious/code/cash_advance/log/cron.log 2>&1 && \
     cd /home/precious/code/cash_advance && RAILS_ENV=development bundle exec rails runner 'RepaymentSchedule.update_cashadvreq_status_to_settled' >> /home/precious/code/cash_advance/log/cron.log 2>&1
   CMD
+  
 end
   
   

--- a/db/migrate/20250424072824_change_payroll_amounts_to_decimal_with_scale.rb
+++ b/db/migrate/20250424072824_change_payroll_amounts_to_decimal_with_scale.rb
@@ -1,0 +1,10 @@
+class ChangePayrollAmountsToDecimalWithScale < ActiveRecord::Migration[6.0]
+  def change
+    change_column :payrolls, :basic, :decimal, precision: 10, scale: 2
+    change_column :payrolls, :sss, :decimal, precision: 10, scale: 2
+    change_column :payrolls, :philhealth, :decimal, precision: 10, scale: 2
+    change_column :payrolls, :pagibig, :decimal, precision: 10, scale: 2
+    change_column :payrolls, :cashadv, :decimal, precision: 10, scale: 2
+    change_column :payrolls, :net_amount, :decimal, precision: 10, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_04_10_052111) do
+ActiveRecord::Schema.define(version: 2025_04_24_072824) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -91,12 +91,12 @@ ActiveRecord::Schema.define(version: 2025_04_10_052111) do
   create_table "payrolls", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "description"
-    t.decimal "basic", precision: 10
-    t.decimal "sss", precision: 10
-    t.decimal "philhealth", precision: 10
-    t.decimal "pagibig", precision: 10
-    t.integer "cashadv"
-    t.decimal "net_amount", precision: 10
+    t.decimal "basic", precision: 10, scale: 2
+    t.decimal "sss", precision: 10, scale: 2
+    t.decimal "philhealth", precision: 10, scale: 2
+    t.decimal "pagibig", precision: 10, scale: 2
+    t.decimal "cashadv", precision: 10, scale: 2
+    t.decimal "net_amount", precision: 10, scale: 2
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_payrolls_on_user_id"
@@ -161,6 +161,7 @@ ActiveRecord::Schema.define(version: 2025_04_10_052111) do
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["employee_id"], name: "index_users_on_employee_id", unique: true
+    t.index ["employee_id"], name: "unique_employee_id", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
@@ -174,9 +175,10 @@ ActiveRecord::Schema.define(version: 2025_04_10_052111) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "audit_logs", "users"
+  add_foreign_key "audit_logs", "users", on_delete: :cascade
   add_foreign_key "cash_adv_requests", "users", column: "approver_id", primary_key: "employee_id"
   add_foreign_key "cash_adv_requests", "users", column: "employee_id", primary_key: "employee_id"
+  add_foreign_key "cash_adv_requests", "users", column: "employee_id", primary_key: "employee_id", name: "fk_employee_id", on_delete: :cascade
   add_foreign_key "notifications", "cash_adv_requests"
   add_foreign_key "notifications", "repayment_schedules"
   add_foreign_key "payrolls", "users"


### PR DESCRIPTION
Changed data types of basic, sss, philhealth, pagibig, cashadv, and net_amount columns to decimal(10,2) for consistent precision
Updated payroll PDF view to display monetary values with two decimal places using number_with_precision
Adjusted due-to-next-payroll logic in dashboard to handle date ranges for 1–15 and 16–end of month periods